### PR TITLE
Inherit from TargetWithContext and use NLog Layouts

### DIFF
--- a/NLog.Targets.OpenTelemetryProtocol.Test/nlog.config
+++ b/NLog.Targets.OpenTelemetryProtocol.Test/nlog.config
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	  throwConfigExceptions="true">
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		throwConfigExceptions="true"
+		internalLogLevel="Debug"
+		internalLogToConsole="true">
 
 	<extensions>
 		<add assembly="NLog.Targets.OpenTelemetryProtocol"/>
@@ -9,16 +11,19 @@
 
 	<targets>
 		<target xsi:type="OtlpTarget"
-		  name="otlp"
-		  usehttp="true"
-		  resources="process.name=${processname};process.id=${processid};deployment.environment=DEV"
-		  attributes="thread.id=${threadid}"
-		  servicename="TestService"
-		  scheduledDelayMilliseconds="1000"
-		  useDefaultResources="false"
-		  includeFormattedMessage="false"/>
+			name="otlp"
+			usehttp="true"
+			servicename="TestService"
+			scheduledDelayMilliseconds="1000"
+			useDefaultResources="false"
+			includeFormattedMessage="false">
+			<attribute name="thread.id" layout="${threadid}" />
+			<resource name="process.name" layout="${processname}" />
+			<resource name="process.id" layout="${processid}" />
+			<resource name="deployment.environment" layout="DEV" />
+		</target>
 	</targets>
-	
+
 	<rules>
 
 		<logger name="*" writeTo="otlp" />

--- a/NLog.Targets.OpenTelemetryProtocol/Exceptions/FailedToParseAttributesException.cs
+++ b/NLog.Targets.OpenTelemetryProtocol/Exceptions/FailedToParseAttributesException.cs
@@ -1,7 +1,0 @@
-﻿namespace NLog.Targets.OpenTelemetryProtocol.Exceptions
-{
-    internal class FailedToParseAttributesException : NLogConfigurationException
-    {
-        internal FailedToParseAttributesException(string message) : base(message) { }
-    }
-}

--- a/NLog.Targets.OpenTelemetryProtocol/OtlpTarget.cs
+++ b/NLog.Targets.OpenTelemetryProtocol/OtlpTarget.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using NLog.Common;
 using NLog.Config;
 using NLog.Layouts;
@@ -162,14 +163,6 @@ namespace NLog.Targets
 
             attributes.Add(OriginalFormatName, logEvent.Message);
 
-            if (IncludeEventParameters && logEvent.Parameters?.Length > 0)
-            {
-                for (int i = 0; i < logEvent.Parameters.Length; i++)
-                {
-                    attributes.Add($"{i}", logEvent.Parameters[i]);
-                }
-            }
-
             if (ShouldIncludeProperties(logEvent))
             {
                 var properties = GetAllProperties(logEvent);
@@ -178,16 +171,46 @@ namespace NLog.Targets
                     attributes.Add(property.Key, property.Value);
                 }
             }
-            else if (ContextProperties?.Count > 0)
+            else
             {
-                foreach (var property in ContextProperties)
+                if (IncludeEventParameters && logEvent.Parameters?.Length > 0)
                 {
-                    var value = property.RenderValue(logEvent);
-                    if (!property.IncludeEmptyValue && (value is null || string.Empty.Equals(value)))
-                        continue;
-
-                    attributes.Add(property.Name, value);
+                    for (int i = 0; i < logEvent.Parameters.Length; i++)
+                    {
+                        attributes.Add(ResolveParameterKey(i), logEvent.Parameters[i]);
+                    }
                 }
+
+                if (ContextProperties?.Count > 0)
+                {
+                    for (int i = 0; i< ContextProperties.Count; i++)
+                    {
+                        var property = ContextProperties[i];
+                        var value = property.RenderValue(logEvent);
+                        if (!property.IncludeEmptyValue && (value is null || string.Empty.Equals(value)))
+                            continue;
+
+                        attributes.Add(property.Name, value);
+                    }
+                }
+            }
+        }
+
+        private static string ResolveParameterKey(int index)
+        {
+            switch (index)
+            {
+                case 0: return "0";
+                case 1: return "1";
+                case 2: return "2";
+                case 3: return "3";
+                case 4: return "4";
+                case 5: return "5";
+                case 6: return "6";
+                case 7: return "7";
+                case 8: return "8";
+                case 9: return "9";
+                default: return index.ToString(CultureInfo.InvariantCulture);
             }
         }
 

--- a/NLog.Targets.OpenTelemetryProtocol/OtlpTarget.cs
+++ b/NLog.Targets.OpenTelemetryProtocol/OtlpTarget.cs
@@ -55,7 +55,7 @@ namespace NLog.Targets
 
         protected override void InitializeTarget()
         {
-            var endPoint = RenderLogEvent(Endpoint, LogEventInfo.CreateNullEvent());
+            var endpoint = RenderLogEvent(Endpoint, LogEventInfo.CreateNullEvent());
             var useHttp = RenderLogEvent(UseHttp, LogEventInfo.CreateNullEvent());
             var headers = RenderLogEvent(Headers, LogEventInfo.CreateNullEvent());
             var maxQueueSize = RenderLogEvent(MaxQueueSize, LogEventInfo.CreateNullEvent(), 2048);
@@ -63,7 +63,7 @@ namespace NLog.Targets
             var scheduledDelayMilliseconds = RenderLogEvent(ScheduledDelayMilliseconds, LogEventInfo.CreateNullEvent(), 5000);
             var includeFormattedMessage = RenderLogEvent(IncludeFormattedMessage, LogEventInfo.CreateNullEvent());
 
-            _processor = CreateProcessor(endPoint, useHttp, headers, maxQueueSize, maxExportBatchSize, scheduledDelayMilliseconds);
+            _processor = CreateProcessor(endpoint, useHttp, headers, maxQueueSize, maxExportBatchSize, scheduledDelayMilliseconds);
             var resourceBuilder = CreateResourceBuilder();
             
             _logger = Sdk
@@ -160,11 +160,9 @@ namespace NLog.Targets
             if (logEvent.Exception != null)
                 attributes.RecordException(logEvent.Exception);
 
-            if (logEvent.HasProperties)
-            {
-                attributes.Add(OriginalFormatName, logEvent.Message);
-            }
-            else if (IncludeEventParameters && logEvent.Parameters?.Length > 0)
+            attributes.Add(OriginalFormatName, logEvent.Message);
+
+            if (IncludeEventParameters && logEvent.Parameters?.Length > 0)
             {
                 for (int i = 0; i < logEvent.Parameters.Length; i++)
                 {

--- a/README.md
+++ b/README.md
@@ -20,15 +20,17 @@ Example XML config:
       <target xsi:type="OtlpTarget"
         name="otlp"
         usehttp="true"
-        resources="process.name=${processname};process.id=${processid};deployment.environment=DEV"
-        attributes="thread.id=${thread.id}"
         servicename="TestService"
         scheduledDelayMilliseconds="1000"
         useDefaultResources="false"
-        includeFormattedMessage="true"/>
+        includeFormattedMessage="true">
+          <attribute name="thread.id" layout="${threadid}" />
+          <resource name="process.name" layout="${processname}" />
+          <resource name="process.id" layout="${processid}" />
+          <resource name="deployment.environment" layout="DEV" />
+      </target>
     </targets>
     <rules>
-        
         <logger name="*" writeTo="otlp" />
     </rules>
 </nlog>
@@ -40,15 +42,22 @@ Example XML config:
 - **Endpoint** : Determines where the exporter should send logs. Used to set OtlpExporterOptions.Endpoint. 
 If left empty, the default values will be used (optional)
 - **Headers** : Used to set OtlpExporterOptions.Headers (optional)
-- **Resources** : Used to set resources in the ResourceBuilder. It must be in the format like in the example above (optional)
 - **ServiceName** : Used to set the service.name resource (optional)
-- **Attributes** : Attributes which each log should contain. It must be in the same format as resources. Attributes are rendered 
-everytime a log is written, so if an attribute would have the same value in all logs, set it in resources instead.
-- **ScheduledDelayMilliseconds** : The target uses a batch exporter, this defines how often it is flushed in milliseconds. 
-By default 5000, optional
+- **Resource** : Additional resources to include in the ResourceBuilder (optional)
+  - _Name_ : Name of Resource.
+  - _Layout_ : Value of Resource (Will only resolve value at target initialize)
+- **Attribute** : Attributes to be included with each LogEvent (optional)
+  - _Name_ : Name of Attribute.
+  - _Layout_ : Value of Attribute (If value is the same for all LogEvents, then add as resource instead)
+- **MaxQueueSize** : The target uses a batch exporter, this defines the max queue size. By default 2048, optional.
+- **MaxExportBatchSize** : The target uses a batch exporter, this defines the max batch size. By default 512, optional.
+- **ScheduledDelayMilliseconds** : The target uses a batch exporter, this defines how often it is flushed in milliseconds. By default 5000, optional.
 - **UseDefaultResources** : By default each exported batch will contain the resources telemetry.sdk.name, telemetry.sdk.language and telemetry.sdk.version. 
 If you don't want them, set to false.
 - **IncludeFormattedMessage** : If you're doing structured logging, this determines whether the body of the outputted log 
 should be the formatted message or the message template. By default false, meaning the body of the outputted log will be the message template.
 If you aren't doing structured logging, leave this as false.
+- **IncludeEventProperties** : If you're doing structured logging, this determines whether to include NLog LogEvent properties as attributes. By default true, optional.
+- **IncludeScopeProperties** : If you're doing structured logging, this determines whether to include NLog ScopeContext properties as attributes. By default false, optional.
+- **IncludeEventParameters** : Whether to fallback to including NLog LogEvent parameters as attributes, when no NLog LogEvent properties. By default false, optional.
 


### PR DESCRIPTION
Updated to use the TargetWithContext that makes it easier to capture NLog-context:

- See also: https://github.com/NLog/NLog/wiki/How-to-write-a-custom-target-for-structured-logging

Replaced the following properites with `ArrayParameter`:
- Resources
- Attributes

Change the following properties to use NLog Layout (Allow target-configuration using `${configsetting}`)
- Layout - Instead of LogEventInfo.FormattedMessage. Default: `${message}`
- EndPoint
- Headers
- UseHttp
- ScheduledDelayMilliseconds
- UseDefaultResources
- IncludeFormattedMessage

Added the following new properties:
- MaxQueueSize
- MaxExportBatchSize
- IncludeEventProperties - Inherited from TargetWithContext. Default: `true`
- IncludeScopeProperties - Inherited from TargetWithContext. Default: `false`
- IncludeEventParameters. Default: `false`