### PR TITLE
OpenTelemetryEventListener can redirect to NLog InternalLogger

### DIFF
--- a/NLog.Targets.OpenTelemetryProtocol/OpenTelemetryEventListener.cs
+++ b/NLog.Targets.OpenTelemetryProtocol/OpenTelemetryEventListener.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+
+namespace NLog.Targets.OpenTelemetryProtocol
+{
+    /// <summary>
+    /// Redirects output from OpenTelemetry EventSource to NLog InternalLogger
+    /// </summary>
+    internal class OpenTelemetryEventListener : EventListener
+    {
+        private const string EventSourceNamePrefix = "OpenTelemetry-";
+        private readonly OtlpTarget _ownerTarget;
+
+        internal static EventLevel EventLevel { get; set; } = EventLevel.LogAlways;
+
+        public OpenTelemetryEventListener(OtlpTarget ownerTarget)
+        {
+            if (EventLevel == EventLevel.LogAlways)
+                throw new InvalidOperationException("Must initialize EventLevel before calling constructor");
+
+            _ownerTarget = ownerTarget;
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            if (eventData.EventSource.Name.StartsWith(EventSourceNamePrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                WriteEvent(eventData.Level, eventData.Message, eventData.Payload);
+            }
+        }
+
+        private void WriteEvent(EventLevel eventLevel, string? eventMessage, IReadOnlyList<object> payload)
+        {
+            switch (eventLevel)
+            {
+                case EventLevel.Informational:
+                    if (NLog.Common.InternalLogger.IsInfoEnabled)
+                    {
+                        WriteInternalLogger(LogLevel.Info, eventMessage, payload);
+                    } break;
+                case EventLevel.Warning:
+                    if (NLog.Common.InternalLogger.IsWarnEnabled)
+                    {
+                        WriteInternalLogger(LogLevel.Warn, eventMessage, payload);
+                    }
+                    break;
+                case EventLevel.Error:
+                    if (NLog.Common.InternalLogger.IsErrorEnabled)
+                    {
+                        WriteInternalLogger(LogLevel.Error, eventMessage, payload);
+                    }
+                    break;
+                case EventLevel.Critical:
+                    if (NLog.Common.InternalLogger.IsFatalEnabled)
+                    {
+                        WriteInternalLogger(LogLevel.Fatal, eventMessage, payload);
+                    }
+                    break;
+                default:
+                    if (NLog.Common.InternalLogger.IsDebugEnabled)
+                    {
+                        WriteInternalLogger(LogLevel.Debug, eventMessage, payload);
+                    }
+                    break;
+            }
+        }
+
+        private void WriteInternalLogger(LogLevel logLevel, string eventMessage, IReadOnlyList<object> payload)
+        {
+            if (payload is null || payload.Count == 0)
+            {
+                NLog.Common.InternalLogger.Log(logLevel, "{0}: {1}", _ownerTarget, eventMessage);
+            }
+            else if (payload.Count == 1)
+            {
+                NLog.Common.InternalLogger.Log(logLevel, "{0}: {1} {2}", _ownerTarget, eventMessage, payload[0]);
+            }
+            else if (payload.Count == 2)
+            {
+                NLog.Common.InternalLogger.Log(logLevel, "{0}: {1} {2} {3}", _ownerTarget, eventMessage, payload[0], payload[1]);
+            }
+            else if (payload.Count == 3)
+            {
+                NLog.Common.InternalLogger.Log(logLevel, "{0}: {1} {2} {3} {4}", _ownerTarget, eventMessage, payload[0], payload[1], payload[2]);
+            }
+            else
+            {
+                NLog.Common.InternalLogger.Log(logLevel, "{0}: {1} {2} {3} {4} {5}", _ownerTarget, eventMessage, payload[0], payload[1], payload[2], payload[3]);
+            }
+        }
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            if (eventSource.Name.StartsWith(EventSourceNamePrefix, StringComparison.Ordinal))
+            {
+                this.EnableEvents(eventSource, EventLevel, EventKeywords.All);
+            }
+
+            base.OnEventSourceCreated(eventSource);
+        }
+    }
+}


### PR DESCRIPTION
This will make it easier for users to diagnose, why the OpenTelemetry-Exporter is failing, by looking at the NLog InternalLogger.

Example output:
```
2024-10-18 16:15:39.2838 Debug OtlpTarget(Name=otlp): LoggerProviderSdk event: '{0}' Building LoggerProvider.
2024-10-18 16:15:39.2966 Debug OtlpTarget(Name=otlp): LoggerProviderSdk event: '{0}' Completed adding processor = "Setting processor to 'LogRecordProcessor'".
2024-10-18 16:15:39.2966 Debug OtlpTarget(Name=otlp): LoggerProviderSdk event: '{0}' Using shared thread pool.
2024-10-18 16:15:39.2966 Debug OtlpTarget(Name=otlp): LoggerProviderSdk event: '{0}' Completed adding processor = "Creating new composite processor and adding new processor 'BatchLogRecordExportProcessor{OtlpLogExporter}'".
2024-10-18 16:15:39.2966 Debug OtlpTarget(Name=otlp): LoggerProviderSdk event: '{0}' LoggerProviderSdk built successfully.

2024-10-18 16:15:44.5501 Error OtlpTarget(Name=otlp): Exporter failed send data to collector to {0} endpoint. Data will not be sent. Exception: {1} http://localhost:4318/v1/logs System.Net.Http.HttpRequestException: No connection could be made because the target machine actively refused it. (localhost:4318)
 ---> System.Net.Sockets.SocketException (10061): No connection could be made because the target machine actively refused it.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource.GetResult(Int16 token)
   at System.Net.Sockets.Socket.<ConnectAsync>g__WaitForConnectWithCancellation|277_0(AwaitableSocketAsyncEventArgs saea, ValueTask connectTask, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.ConnectToTcpHostAsync(String host, Int32 port, HttpRequestMessage initialRequest, Boolean async, CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at System.Net.Http.HttpConnectionPool.ConnectToTcpHostAsync(String host, Int32 port, HttpRequestMessage initialRequest, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.ConnectAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.CreateHttp11ConnectionAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.AddHttp11ConnectionAsync(HttpRequestMessage request)
   at System.Threading.Tasks.TaskCompletionSourceWithCancellation`1.WaitWithCancellationAsync(CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.GetHttp11ConnectionAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.SendWithVersionDetectionAndRetryAsync(HttpRequestMessage request, Boolean async, Boolean doRequestAuth, CancellationToken cancellationToken)
   at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
   at OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient.BaseOtlpHttpExportClient`1.SendExportRequest(TRequest request, DateTime deadlineUtc, CancellationToken cancellationToken)
```