### PR TITLE
Dependency update OpenTelemetry ver. 1.11.0-rc.1

### DIFF
--- a/Benchmark/Benchmark.csproj
+++ b/Benchmark/Benchmark.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFrameworks>net48;net6.0</TargetFrameworks>
+		<TargetFrameworks>net48;net8.0</TargetFrameworks>
 		<LangVersion>Latest</LangVersion>
 		<Configurations>Debug;Release;Test;Test</Configurations>
 	</PropertyGroup>

--- a/NLog.Targets.OpenTelemetryProtocol.Test/NLog.Targets.OpenTelemetryProtocol.Test.csproj
+++ b/NLog.Targets.OpenTelemetryProtocol.Test/NLog.Targets.OpenTelemetryProtocol.Test.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
-		<LangVersion>Latest</LangVersion>
-		<Configurations>Debug;Release;Test;Test</Configurations>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>Latest</LangVersion>
+    <Configurations>Debug;Release;Test</Configurations>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\NLog.Targets.OpenTelemetryProtocol\NLog.Targets.OpenTelemetryProtocol.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NLog.Targets.OpenTelemetryProtocol\NLog.Targets.OpenTelemetryProtocol.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <None Update="nlog.config">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </None>
-    </ItemGroup>
+  <ItemGroup>
+    <None Update="nlog.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/NLog.Targets.OpenTelemetryProtocol.Test/Program.cs
+++ b/NLog.Targets.OpenTelemetryProtocol.Test/Program.cs
@@ -11,6 +11,8 @@ namespace NLog.Targets.OpenTelemetryProtocol.Test
 
             var message = "testing";
 
+            using var currentActivity = new System.Diagnostics.Activity("Hello World").Start();
+
             logger.Fatal("message: {messageField}", message);
 
             Thread.Sleep(10000);

--- a/NLog.Targets.OpenTelemetryProtocol/NLog.Targets.OpenTelemetryProtocol.csproj
+++ b/NLog.Targets.OpenTelemetryProtocol/NLog.Targets.OpenTelemetryProtocol.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
 	<PackageReference Include="NLog" Version="5.0.0" />
-	<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0-beta.1" />
+	<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.0-rc.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(Configuration)' == 'Test' ">

--- a/NLog.Targets.OpenTelemetryProtocol/OpenTelemetryEventListener.cs
+++ b/NLog.Targets.OpenTelemetryProtocol/OpenTelemetryEventListener.cs
@@ -30,7 +30,7 @@ namespace NLog.Targets.OpenTelemetryProtocol
             }
         }
 
-        private void WriteEvent(EventLevel eventLevel, string? eventMessage, IReadOnlyList<object> payload)
+        private void WriteEvent(EventLevel eventLevel, string eventMessage, IReadOnlyList<object> payload)
         {
             switch (eventLevel)
             {

--- a/NLog.Targets.OpenTelemetryProtocol/OtlpTarget.cs
+++ b/NLog.Targets.OpenTelemetryProtocol/OtlpTarget.cs
@@ -353,7 +353,7 @@ namespace NLog.Targets
 
         private OpenTelemetry.Logs.Logger GetLogger(string name)
         {
-            if (!_loggers.TryGetValue(name, out OpenTelemetry.Logs.Logger? logger))
+            if (!_loggers.TryGetValue(name, out OpenTelemetry.Logs.Logger logger))
             {
                 lock (_sync)
                 {

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This target can export logs in the format defined in the OpenTelemetry specifica
 For an explanation of the log data model, see https://opentelemetry.io/docs/specs/otel/logs/data-model/. <br>
 For an example, see https://opentelemetry.io/docs/specs/otel/protocol/file-exporter/#examples.
 
-**Note that the OpenTelemetry logging API is still unfinished, which means that it is internal in stable releases and public in prelease versions of the OpenTelemetry package.
-This package has a reference to OpenTelemetry version 1.9.0-alpha.1. If your project has a reference to a stable version higher than that,
+**Note that the OpenTelemetry logging API is still unfinished, which means that it is internal in stable releases and public in pre-release versions of the OpenTelemetry package.
+This package has a reference to pre-release version of the OpenTelemetry-nuget-package. If your project has a reference to a stable version higher than that,
 you will get a runtime error.**
 
 ## Configuration
@@ -29,7 +29,7 @@ Example XML config:
         scheduledDelayMilliseconds="1000"
         useDefaultResources="false"
         includeFormattedMessage="true"
-        onlyIncldueParameters="correlationId,messageId">
+        onlyIncludeProperties="correlationId,messageId">
           <attribute name="thread.id" layout="${threadid}" />
           <resource name="process.name" layout="${processname}" />
           <resource name="process.id" layout="${processid}" />

--- a/TestWebApp/TestWebApp.csproj
+++ b/TestWebApp/TestWebApp.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog.Web.AspNetCore" Version="5.3.8" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="5.3.15" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitTests/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.csproj
+++ b/UnitTests/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.csproj
@@ -1,40 +1,40 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
 
-        <IsPackable>false</IsPackable>
+    <IsPackable>false</IsPackable>
 
-        <SignAssembly>True</SignAssembly>
+    <SignAssembly>True</SignAssembly>
 
-        <AssemblyOriginatorKeyFile>debug.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>debug.snk</AssemblyOriginatorKeyFile>
 
-        <Configurations>Debug;Release;Test;Test</Configurations>
-    </PropertyGroup>
+    <Configurations>Debug;Release;Test</Configurations>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\NLog.Targets.OpenTelemetryProtocol\NLog.Targets.OpenTelemetryProtocol.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NLog.Targets.OpenTelemetryProtocol\NLog.Targets.OpenTelemetryProtocol.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <None Update="nlog.config">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </None>
-    </ItemGroup>
+  <ItemGroup>
+    <None Update="nlog.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
One might consider making this NLog target a wrapper around the public `OpenTelemetryLoggerProvider`.

Then "just" inject a [special LogEvent-state-object](https://github.com/NLog/NLog.Extensions.Logging/wiki/NLog-properties-with-Microsoft-Extension-Logging#logtstate-advanced) that includes the NLog LogEventInfo-properties. Maybe consider making a pull-request so one can override the checking of global/static property `Sdk.SuppressInstrumentation`:
```c#
    public bool IsEnabled(LogLevel logLevel)
    {
        return logLevel != LogLevel.None && !Sdk.SuppressInstrumentation;
    }
```