### PR TITLE
Async wrapper

### DIFF
--- a/NLog.Targets.OpenTelemetryProtocol.Test/Program.cs
+++ b/NLog.Targets.OpenTelemetryProtocol.Test/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿using NLog.Targets.Wrappers;
+using System;
+using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 
 namespace NLog.Targets.OpenTelemetryProtocol.Test
@@ -13,6 +16,7 @@ namespace NLog.Targets.OpenTelemetryProtocol.Test
 
             using var currentActivity = new System.Diagnostics.Activity("Hello World").Start();
 
+            logger.Fatal("message: {messageField}", message);
             logger.Fatal("message: {messageField}", message);
 
             Thread.Sleep(10000);

--- a/NLog.Targets.OpenTelemetryProtocol.Test/nlog.config
+++ b/NLog.Targets.OpenTelemetryProtocol.Test/nlog.config
@@ -29,7 +29,6 @@
 	</targets>
 
 	<rules>
-
 		<logger name="*" writeTo="otlp" />
 	</rules>
 </nlog>

--- a/NLog.Targets.OpenTelemetryProtocol/ActivityExtensions.cs
+++ b/NLog.Targets.OpenTelemetryProtocol/ActivityExtensions.cs
@@ -1,0 +1,52 @@
+﻿using System.Diagnostics;
+
+namespace NLog.Targets.OpenTelemetryProtocol
+{
+    /// <summary>
+    /// Formats elements of <see cref="Activity.Current"/> for inclusion in log events. Non-W3C-format activities are
+    /// ignored (Seq does not support the older Microsoft-proprietary hierarchical activity id format).
+    /// </summary>
+    internal static class ActivityExtensions
+    {
+        private static readonly System.Diagnostics.ActivitySpanId EmptySpanId = default(System.Diagnostics.ActivitySpanId);
+        private static readonly System.Diagnostics.ActivityTraceId EmptyTraceId = default(System.Diagnostics.ActivityTraceId);
+
+        public static string GetSpanId(this Activity activity)
+        {
+            return activity.IdFormat == ActivityIdFormat.W3C ?
+                SpanIdToHexString(activity.SpanId) :
+                string.Empty;
+        }
+
+        public static string GetTraceId(this Activity activity)
+        {
+            return activity.IdFormat == ActivityIdFormat.W3C ?
+                TraceIdToHexString(activity.TraceId) :
+                string.Empty;
+        }
+
+        private static string SpanIdToHexString(ActivitySpanId spanId)
+        {
+            if (EmptySpanId.Equals(spanId))
+                return string.Empty;
+
+            var spanHexString = spanId.ToHexString();
+            if (ReferenceEquals(spanHexString, EmptySpanId.ToHexString()))
+                return string.Empty;
+
+            return spanHexString;
+        }
+
+        private static string TraceIdToHexString(ActivityTraceId traceId)
+        {
+            if (EmptyTraceId.Equals(traceId))
+                return string.Empty;
+
+            var traceHexString = traceId.ToHexString();
+            if (ReferenceEquals(traceHexString, EmptyTraceId.ToHexString()))
+                return string.Empty;
+
+            return traceHexString;
+        }
+    }
+}

--- a/UnitTests/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.csproj
+++ b/UnitTests/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.csproj
@@ -60,6 +60,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="nlog2.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="nlog.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/UnitTests/nlog2.config
+++ b/UnitTests/nlog2.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		throwConfigExceptions="true"
+		internalLogLevel="Debug"
+		internalLogToConsole="true">
+
+	<extensions>
+		<add assembly="NLog.Targets.OpenTelemetryProtocol"/>
+	</extensions>
+
+	<targets async="true">
+		<target xsi:type="OtlpTarget"
+			name="otlp"
+			usehttp="true"
+			servicename="TestService"
+			scheduledDelayMilliseconds="1000"
+			useDefaultResources="false"
+			includeFormattedMessage="false">
+		</target>
+	</targets>
+
+	<rules>
+
+    <logger name="*" writeTo="otlp" />
+	</rules>
+</nlog>


### PR DESCRIPTION
The change is largely based on https://github.com/juliuskoval/NLog.Targets.OpenTelemetryProtocol/commit/1d5610258e58f7bf165aa59f6c8b591049a8239e.
Here are benchmarks for comparison
![image](https://github.com/user-attachments/assets/6346eff2-5d8b-4bf2-87a8-9bd9f74376a0)
The top is without the change, the bottom with the change if I don't check for whether the target is wrapped. Interestingly, more memory is allocated on .NET 8.0 in the second case.