### PR TITLE
Added netstandard2.1 to TargetFrameworks

### DIFF
--- a/NLog.Targets.OpenTelemetryProtocol/NLog.Targets.OpenTelemetryProtocol.csproj
+++ b/NLog.Targets.OpenTelemetryProtocol/NLog.Targets.OpenTelemetryProtocol.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-	<LangVersion>Latest</LangVersion>
-	<Version>1.1.7</Version>
-	<Authors>Julius Koval</Authors>
-	<Description>NLog target used to export logs in the standardized OpenTelemetry format</Description>
-	<IncludeSymbols>True</IncludeSymbols>
-	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-	<PackageTags>Logging;NLog;OpenTelemetry;OpenTelemetryProtocol</PackageTags>
-	<PackageProjectUrl>https://github.com/juliuskoval/NLog.Targets.OpenTelemetryProtocol</PackageProjectUrl>
-	<RepositoryUrl>https://github.com/juliuskoval/NLog.Targets.OpenTelemetryProtocol</RepositoryUrl>
-	<PackageId>NLog.Targets.OpenTelemetryProtocol</PackageId>
-	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	<PackageReadmeFile>README.md</PackageReadmeFile>
-	<Configurations>Debug;Release;Test;Test</Configurations>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <LangVersion>Latest</LangVersion>
+    <Version>1.1.8</Version>
+    <Authors>Julius Koval</Authors>
+    <Description>NLog target used to export logs in the standardized OpenTelemetry format</Description>
+    <IncludeSymbols>True</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageTags>Logging;NLog;OpenTelemetry;OpenTelemetryProtocol</PackageTags>
+    <PackageProjectUrl>https://github.com/juliuskoval/NLog.Targets.OpenTelemetryProtocol</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/juliuskoval/NLog.Targets.OpenTelemetryProtocol</RepositoryUrl>
+    <PackageId>NLog.Targets.OpenTelemetryProtocol</PackageId>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <Configurations>Debug;Release;Test;Test</Configurations>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,11 +25,11 @@
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="NLog" Version="5.3.4" />
-	<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.0-rc.1" />
+    <PackageReference Include="NLog" Version="5.3.4" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.0-rc.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(Configuration)' == 'Test' ">
-  	<PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.10.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.11.0-rc.1" />
   </ItemGroup>
 </Project>

--- a/NLog.Targets.OpenTelemetryProtocol/OtlpTarget.cs
+++ b/NLog.Targets.OpenTelemetryProtocol/OtlpTarget.cs
@@ -21,6 +21,9 @@ namespace NLog.Targets
     [Target("OtlpTarget")]
     public class OtlpTarget : TargetWithContext
     {
+        private static readonly System.Diagnostics.ActivitySpanId EmptySpanId = default(System.Diagnostics.ActivitySpanId);
+        private static readonly System.Diagnostics.ActivityTraceId EmptyTraceId = default(System.Diagnostics.ActivityTraceId);
+
         private LoggerProvider _loggerProvider;
 
         private BatchLogRecordExportProcessor _processor;
@@ -59,9 +62,9 @@ namespace NLog.Targets
 
         public HashSet<string> OnlyIncludeProperties { get; set; }
 
-        public Layout<System.Diagnostics.ActivityTraceId?> TraceId { get; set; } = Layout<System.Diagnostics.ActivityTraceId?>.FromMethod(evt => System.Diagnostics.Activity.Current?.TraceId);
+        public Layout<System.Diagnostics.ActivityTraceId?> TraceId { get; set; } = Layout<System.Diagnostics.ActivityTraceId?>.FromMethod(static evt => System.Diagnostics.Activity.Current?.TraceId is System.Diagnostics.ActivityTraceId activityTraceId && !activityTraceId.Equals(EmptyTraceId) ? activityTraceId : null);
 
-        public Layout<System.Diagnostics.ActivitySpanId?> SpanId { get; set; } = Layout<System.Diagnostics.ActivitySpanId?>.FromMethod(evt => System.Diagnostics.Activity.Current?.SpanId);
+        public Layout<System.Diagnostics.ActivitySpanId?> SpanId { get; set; } = Layout<System.Diagnostics.ActivitySpanId?>.FromMethod(static evt => System.Diagnostics.Activity.Current?.SpanId is System.Diagnostics.ActivitySpanId activitySpanId && !activitySpanId.Equals(EmptySpanId) ? activitySpanId : null);
 
         [ArrayParameter(typeof(TargetPropertyWithContext), "resource")]
         public IList<TargetPropertyWithContext> Resources { get; } = new List<TargetPropertyWithContext>();

--- a/UnitTests/TargetTests.cs
+++ b/UnitTests/TargetTests.cs
@@ -36,7 +36,7 @@ public class TargetTests
 
         Assert.Single(target.LogRecords);
 
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0]);
+        OtlpLogs.LogRecord otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0])!;
 
         Assert.Equal(expectedMessage, otlpLogRecord.Body.StringValue);
         Assert.True(otlpLogRecord.Attributes.Count() == 2);
@@ -72,7 +72,7 @@ public class TargetTests
 
         Assert.Single(target.LogRecords);
 
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0]);
+        OtlpLogs.LogRecord otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0])!;
 
         Assert.Equal(expectedMessage, otlpLogRecord.Body.StringValue);
         Assert.True(otlpLogRecord.Attributes.Count() == 2);
@@ -99,14 +99,11 @@ public class TargetTests
         LogManager.ReconfigExistingLoggers();
 
         var message = "message without parameters";
-
-
         logger.Info(message);
 
         Assert.Single(target.LogRecords);
 
-
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0]);
+        OtlpLogs.LogRecord otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0])!;
 
         Assert.Equal(message, otlpLogRecord.Body.StringValue);
         Assert.True(otlpLogRecord.Attributes.Count() == 0);
@@ -128,13 +125,11 @@ public class TargetTests
         var parameter = "testing";
         var expectedMessage = "message : testing";
 
-
         logger.Info(message, parameter);
 
         Assert.Single(target.LogRecords);
 
-
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0]);
+        OtlpLogs.LogRecord otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0])!;
 
         Assert.Equal(expectedMessage, otlpLogRecord.Body.StringValue);
         Assert.True(otlpLogRecord.Attributes.Count() == 2);
@@ -170,8 +165,7 @@ public class TargetTests
 
         Assert.Single(target.LogRecords);
 
-
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0]);
+        OtlpLogs.LogRecord otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0])!;
 
         Assert.Equal(expectedMessage, otlpLogRecord.Body.StringValue);
         Assert.Single(otlpLogRecord.Attributes);
@@ -203,8 +197,7 @@ public class TargetTests
 
         Assert.Single(target.LogRecords);
 
-
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0]);
+        OtlpLogs.LogRecord otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0])!;
 
         Assert.Equal(message, otlpLogRecord.Body.StringValue);
         Assert.Single(otlpLogRecord.Attributes);
@@ -234,8 +227,7 @@ public class TargetTests
 
         Assert.Single(target.LogRecords);
 
-
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0]);
+        OtlpLogs.LogRecord otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0])!;
 
         Assert.Equal(message, otlpLogRecord.Body.StringValue);
         Assert.Empty(otlpLogRecord.Attributes);
@@ -261,8 +253,7 @@ public class TargetTests
 
         Assert.Single(target.LogRecords);
 
-
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0]);
+        OtlpLogs.LogRecord otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0])!;
 
         Assert.Equal(message, otlpLogRecord.Body.StringValue);
         Assert.Single(otlpLogRecord.Attributes);
@@ -293,7 +284,7 @@ public class TargetTests
 
         Assert.Single(target.LogRecords);
 
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0]);
+        OtlpLogs.LogRecord otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0])!;
 
         Assert.Equal(message, otlpLogRecord.Body.StringValue);
         Assert.Empty(otlpLogRecord.Attributes);
@@ -322,7 +313,7 @@ public class TargetTests
 
         Assert.Single(target.LogRecords);
 
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0]);
+        OtlpLogs.LogRecord otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0])!;
 
         Assert.Equal(message, otlpLogRecord.Body.StringValue);
         Assert.Single(otlpLogRecord.Attributes);
@@ -353,7 +344,7 @@ public class TargetTests
 
         Assert.Single(target.LogRecords);
 
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0]);
+        OtlpLogs.LogRecord otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0])!;
 
         Assert.Equal(message, otlpLogRecord.Body.StringValue);
         Assert.True(otlpLogRecord.Attributes.Count() == 2);
@@ -388,7 +379,7 @@ public class TargetTests
 
         Assert.Single(target.LogRecords);
 
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0]);
+        OtlpLogs.LogRecord otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0])!;
 
         Assert.Equal(message, otlpLogRecord.Body.StringValue);
         Assert.Empty(otlpLogRecord.Attributes);
@@ -414,7 +405,7 @@ public class TargetTests
 
         Assert.Single(target.LogRecords);
 
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0]);
+        OtlpLogs.LogRecord otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0])!;
 
         Assert.Equal(message, otlpLogRecord.Body.StringValue);
         Assert.Single(otlpLogRecord.Attributes);
@@ -446,7 +437,7 @@ public class TargetTests
         Assert.Single(target.LogRecords);
 
 
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0]);
+        OtlpLogs.LogRecord otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0])!;
 
         Assert.Equal(message, otlpLogRecord.Body.StringValue);
         Assert.True(otlpLogRecord.Attributes.Count() == 2);
@@ -481,7 +472,7 @@ public class TargetTests
 
         Assert.Single(target.LogRecords);
 
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0]);
+        OtlpLogs.LogRecord otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0])!;
 
         Assert.Equal(message, otlpLogRecord.Body.StringValue);
         Assert.Empty(otlpLogRecord.Attributes);
@@ -504,7 +495,7 @@ public class TargetTests
 
         logger.Info(message);
 
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0]);
+        OtlpLogs.LogRecord otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0])!;
 
         Assert.Equal(currentActivity.TraceId.ToString(), ByteStringToHexString(otlpLogRecord.TraceId));
         Assert.Equal(currentActivity.SpanId.ToString(), ByteStringToHexString(otlpLogRecord.SpanId));
@@ -527,7 +518,7 @@ public class TargetTests
         LogManager.Flush();
 
         Assert.Single(target.LogRecords);
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0]);
+        OtlpLogs.LogRecord otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), target.LogRecords[0])!;
 
         Assert.Equal(currentActivity.TraceId.ToString(), ByteStringToHexString(otlpLogRecord.TraceId));
         Assert.Equal(currentActivity.SpanId.ToString(), ByteStringToHexString(otlpLogRecord.SpanId));


### PR DESCRIPTION
Prepare for new versions of `OpenTelemetry.Exporter.OpenTelemetryProtocol` that adds `Grpc.Core` as direct dependency for NetStandard2.0:

- https://www.nuget.org/packages/OpenTelemetry.Exporter.OpenTelemetryProtocol/1.11.2#dependencies-body-tab