### PR TITLE
 OtlpTarget - Introduced ResolveLoggerProvider to use shared LoggerProvider dependency

### DIFF
--- a/NLog.Targets.OpenTelemetryProtocol/OtlpTarget.cs
+++ b/NLog.Targets.OpenTelemetryProtocol/OtlpTarget.cs
@@ -21,8 +21,8 @@ namespace NLog.Targets
     [Target("OtlpTarget")]
     public class OtlpTarget : TargetWithContext
     {
-        private static readonly System.Diagnostics.ActivitySpanId EmptySpanId = default(System.Diagnostics.ActivitySpanId);
-        private static readonly System.Diagnostics.ActivityTraceId EmptyTraceId = default(System.Diagnostics.ActivityTraceId);
+        private static readonly string EmptyTraceIdToHexString = default(System.Diagnostics.ActivityTraceId).ToHexString();
+        private static readonly string EmptySpanIdToHexString = default(System.Diagnostics.ActivitySpanId).ToHexString();
 
         private LoggerProvider _loggerProvider;
 
@@ -62,9 +62,9 @@ namespace NLog.Targets
 
         public HashSet<string> OnlyIncludeProperties { get; set; }
 
-        public Layout<System.Diagnostics.ActivityTraceId?> TraceId { get; set; } = Layout<System.Diagnostics.ActivityTraceId?>.FromMethod(static evt => System.Diagnostics.Activity.Current?.TraceId is System.Diagnostics.ActivityTraceId activityTraceId && !activityTraceId.Equals(EmptyTraceId) ? activityTraceId : null);
+        public Layout<System.Diagnostics.ActivityTraceId?> TraceId { get; set; } = Layout<System.Diagnostics.ActivityTraceId?>.FromMethod(static evt => System.Diagnostics.Activity.Current?.TraceId is System.Diagnostics.ActivityTraceId activityTraceId && !ReferenceEquals(EmptyTraceIdToHexString, activityTraceId.ToHexString()) ? activityTraceId : null);
 
-        public Layout<System.Diagnostics.ActivitySpanId?> SpanId { get; set; } = Layout<System.Diagnostics.ActivitySpanId?>.FromMethod(static evt => System.Diagnostics.Activity.Current?.SpanId is System.Diagnostics.ActivitySpanId activitySpanId && !activitySpanId.Equals(EmptySpanId) ? activitySpanId : null);
+        public Layout<System.Diagnostics.ActivitySpanId?> SpanId { get; set; } = Layout<System.Diagnostics.ActivitySpanId?>.FromMethod(static evt => System.Diagnostics.Activity.Current?.SpanId is System.Diagnostics.ActivitySpanId activitySpanId && !ReferenceEquals(EmptySpanIdToHexString, activitySpanId.ToHexString()) ? activitySpanId : null);
 
         [ArrayParameter(typeof(TargetPropertyWithContext), "resource")]
         public IList<TargetPropertyWithContext> Resources { get; } = new List<TargetPropertyWithContext>();

--- a/README.md
+++ b/README.md
@@ -70,4 +70,8 @@ If you aren't doing structured logging, leave this as false.
 - **ExcludeProperties** : A list of log event properties which won't be added to the final log as attributes. By default empty, meaning that no log event properties will be excluded.
 - **OnlyIncludeProperties** : A list of log event properties which will be the only ones to be included in the final log. If both this and `ExcludeProperties` are defined,
  this setting will take precedence and `ExcludeProperties` will be ignored.
-- **DisableEventListener** : Disable dynamic configuration of Event Tracing (ETW) listener for detailed NLog InternalLogger output.
+- **resolveLoggerProvider** : Resolve shared OpenTelemetry LoggerProvider using application dependency injection. By default `null`
+  - `null` - Attempt to resolve shared OpenTelemetry LoggerProvider dependency, with fallback to own dedicated LoggerProvider.
+  - `true` - Resolve shared OpenTelemetry LoggerProvider dependency, with fallback to disabling target until dependency is available.
+  - `false` - Always create own dedicated OpenTelemetry LoggerProvider.
+- **DisableEventListener** : Disable dynamic configuration of Event Tracing (ETW) listener for detailed NLog InternalLogger output. By default false, optional.


### PR DESCRIPTION
- **resolveLoggerProvider** : Resolve shared OpenTelemetry LoggerProvider using application dependency injection. By default `null`
  - `null` - Attempt to resolve shared OpenTelemetry LoggerProvider dependency, with fallback to own dedicated LoggerProvider.
  - `true` - Resolve shared OpenTelemetry LoggerProvider dependency, with fallback to disabling target until dependency is available.
  - `false` - Always create own dedicated OpenTelemetry LoggerProvider.

ActivityTraceId.Equals + ActivitySpanId.Equals performs a string-compare. Which should be avoided when just wanting to skip empty / default values.